### PR TITLE
SitemapDB: cascade on server delete

### DIFF
--- a/mobile/src/main/java/treehou/se/habit/core/db/SitemapDB.java
+++ b/mobile/src/main/java/treehou/se/habit/core/db/SitemapDB.java
@@ -20,7 +20,7 @@ public class SitemapDB extends Model {
     @Column(name = "link", unique = true, onUniqueConflict = Column.ConflictAction.REPLACE)
     private String link;
 
-    @Column(name = "server")
+    @Column(name = "server", onDelete = Column.ForeignKeyAction.CASCADE)
     private ServerDB server;
 
     public SitemapDB() {}


### PR DESCRIPTION
This fixes #61, crashing when removing a server.

Unfortunately servers in existing databases will crash if they were not
created with this relation.
